### PR TITLE
initial deb-package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ void             gas_group_set_group_name(GasGroup   *group,
 meson build -Dprefix=/usr
 ninja -C build
 sudo ninja -C build install
+```
 
+## Create deb package on Ubuntu MATE 22.04 LTS
 
+```
+sudo apt-get update
+sudo apt-get install dpkg-dev debhelper-compat meson cmake pkg-config libdbus-1-dev systemd libglib2.0-dev libpolkit-gobject-1-dev polkitd
 
+dpkg-buildpackage -uc -us
+sudo apt-get install ../group-service*.deb
+```

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,5 @@
+group-service (1.3.0-1) jammy; urgency=medium
+
+  * Initial release
+
+ -- N0rbert <nrbrtx@gmail.com>  Fri, 20 May 2022 00:09:59 +0300

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,26 @@
+Source: group-service
+Section: utils
+Priority: optional
+Maintainer: N0rbert <nrbrtx@gmail.com>
+Build-Depends: debhelper-compat (= 13),
+               meson (>= 0.53.0),
+               cmake,
+               pkg-config,
+               libdbus-1-dev,
+               systemd,
+               libglib2.0-dev,
+               libpolkit-gobject-1-dev,
+               polkitd
+Standards-Version: 4.6.0
+Homepage: https://github.com/zhuyaliang/group-service
+Rules-Requires-Root: no
+
+Package: group-service
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: Borrowing DBUS services to manage user groups
+ Using Dbus to manage user groups, you can complete the addition 
+ and deletion of user groups, add \ remove users to groups, and 
+ change the name of user groups.The `test` directory is some 
+ testing process.
+ 

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,11 @@
+#! /usr/bin/make -f
+
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,-O1 -Wl,-z,defs
+
+%:
+	dh $@
+	
+override_dh_auto_test:
+	DEB_BUILD_OPTIONS=nocheck dh_auto_test
+


### PR DESCRIPTION
This is the fix for https://github.com/zhuyaliang/group-service/issues/4 .
You are welcome to change changelog text, maintainer's name and package description.
Currently the package builds normally on Ubuntu MATE 22.04 LTS and interacts with user-admin as it should. 