### PR TITLE
Handle g_spawn_check_{wait,exit}_status according to GLib version

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -199,8 +199,10 @@ static gboolean
 compat_check_exit_status (int      estatus,
                           GError **error)
 {
-#if GLIB_CHECK_VERSION(2, 33, 12)
+#if GLIB_CHECK_VERSION(2, 69, 0)
     return g_spawn_check_wait_status (estatus, error);
+#elif GLIB_CHECK_VERSION(2, 33, 4)
+    return g_spawn_check_exit_status (estatus, error);
 #else
     if (!WIFEXITED (estatus)) 
     {


### PR DESCRIPTION
Commit 83e42892fe5b065456fcdff198273186b179e70a switched from `g_spawn_check_exit_status()` to `g_spawn_check_wait_status()` which breaks Red Hat Enterprise Linux 9 and derivatives, such as Rocky Linux 9 (as discovered by @raveit65 and mentioned in https://github.com/zhuyaliang/group-service/issues/8#issuecomment-1405129339). More backward-compatible way is to check for the actual GLib version:

 - if GLib >= 2.69.0: `g_spawn_check_wait_status()`
 - else if GLib >= 2.33.4: `g_spawn_check_wait_status()`
 - else: [existing compatibility code]

See also:

 - https://github.com/GNOME/glib/blob/main/NEWS
 - https://docs.gtk.org/glib/func.spawn_check_wait_status.html
 - https://docs.gtk.org/glib/func.spawn_check_exit_status.html

Tested with:

 - Fedora Rawhide: glib2-2.74.1-3.fc38
 - Fedora 37: glib2-2.74.1-2.fc37
 - Fedora 36: glib2-2.72.3-1.fc36
 - Rocky Linux 9: glib2-2.68.4-5.el9
 - Rocky Linux 8: glib2-2.56.4-159.el8